### PR TITLE
Use 'ransack' method instead of its 'search' alias

### DIFF
--- a/app/controllers/schemas_controller.rb
+++ b/app/controllers/schemas_controller.rb
@@ -22,7 +22,7 @@ class SchemasController < ApplicationController
       params[:q] = get_search_params_from_session(@database_connection.id, @name)
       @columns_names = @schema.get_table_attributes(@name)
       @model = @schema.get_schemas[@name]
-      @search = @model.search(params[:q], :engine => @model)
+      @search = @model.ransack(params[:q], :engine => @model)
       @collection =  @search.result.page(params[:page]).per(get_per_page(@database_connection.id, @name))
     end
   end


### PR DESCRIPTION
The ransack project readme mentions how the 'ransack' method is an alias for 'search' and that it has been reported that the use of 'search' can cause issues and will be deprecated in future versions. See https://github.com/activerecord-hackery/ransack/blob/master/README.md#ransack-search-method
